### PR TITLE
Rename heroku url

### DIFF
--- a/src/Components/Hint/index.js
+++ b/src/Components/Hint/index.js
@@ -10,7 +10,8 @@ class Hint extends Component {
 
   getCountryOutlinePath = () => {
     const { outline } = this.props
-    const outlineUrl = `https://flagz4u.herokuapp.com${outline}`
+    const outlineUrl = `https://world-of-flags-backend.herokuapp.com${outline}`
+    console.log(outline)
     return outlineUrl
   }
 

--- a/src/Components/Hint/index.js
+++ b/src/Components/Hint/index.js
@@ -11,7 +11,6 @@ class Hint extends Component {
   getCountryOutlinePath = () => {
     const { outline } = this.props
     const outlineUrl = `https://world-of-flags-backend.herokuapp.com${outline}`
-    console.log(outline)
     return outlineUrl
   }
 

--- a/src/Components/Hint/test/Hint.test.js
+++ b/src/Components/Hint/test/Hint.test.js
@@ -52,7 +52,7 @@ describe('Hint', () => {
   describe('getCountryOutlinePath', () => {
     it('should create complete path for country outline', () => {
       const expected =
-        'https://flagz4u.herokuapp.com/images/outlines/netherlands.png'
+        'https://world-of-flags-backend.herokuapp.com/images/outlines/netherlands.png'
       const result = wrapper.instance().getCountryOutlinePath()
       expect(result).toEqual(expected)
     })

--- a/src/Components/Results/index.js
+++ b/src/Components/Results/index.js
@@ -4,11 +4,7 @@ import PropTypes from 'prop-types';
 
 
 class Results extends Component {
-
-  componentDidMount() {
-    console.log(this.props.status)
-  }
-
+  
   handleClick = () => {
     const { getCountry, closeResults } = this.props
 

--- a/src/Containers/Game/index.js
+++ b/src/Containers/Game/index.js
@@ -127,7 +127,7 @@ export class Game extends Component {
 
  getCountryFlagPath = () => {
     const { flag } = this.props.currentCountry;
-    const flagUrl = `https://flagz4u.herokuapp.com${flag}`
+    const flagUrl = `https://world-of-flags-backend.herokuapp.com${flag}`
     return flagUrl;
   }
 

--- a/src/Containers/Game/test/Game.test.js
+++ b/src/Containers/Game/test/Game.test.js
@@ -2,7 +2,6 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import { shallow, mount } from 'enzyme'
 import { Game, mapStateToProps, mapDispatchToProps } from '../index'
-// import { wrap } from 'module';
 
 describe('Game', () => {
   let wrapper
@@ -206,7 +205,7 @@ describe('Game', () => {
     it('should create complete path for country flag', () => {
       let result = wrapper.instance().getCountryFlagPath()
       expect(result).toEqual(
-        'https://flagz4u.herokuapp.com/images/flags/netherlands.png'
+        'https://world-of-flags-backend.herokuapp.com/images/flags/netherlands.png'
       )
     })
   })

--- a/src/Containers/Game/test/__snapshots__/Game.test.js.snap
+++ b/src/Containers/Game/test/__snapshots__/Game.test.js.snap
@@ -85,7 +85,7 @@ ShallowWrapper {
           <img
             alt=""
             className="flag-image"
-            src="https://flagz4u.herokuapp.com/images/flags/netherlands.png"
+            src="https://world-of-flags-backend.herokuapp.com/images/flags/netherlands.png"
           />
         </div>,
         <div
@@ -269,7 +269,7 @@ ShallowWrapper {
           "children": <img
             alt=""
             className="flag-image"
-            src="https://flagz4u.herokuapp.com/images/flags/netherlands.png"
+            src="https://world-of-flags-backend.herokuapp.com/images/flags/netherlands.png"
           />,
           "className": "flag-main",
         },
@@ -281,7 +281,7 @@ ShallowWrapper {
           "props": Object {
             "alt": "",
             "className": "flag-image",
-            "src": "https://flagz4u.herokuapp.com/images/flags/netherlands.png",
+            "src": "https://world-of-flags-backend.herokuapp.com/images/flags/netherlands.png",
           },
           "ref": null,
           "rendered": null,
@@ -403,7 +403,7 @@ ShallowWrapper {
             <img
               alt=""
               className="flag-image"
-              src="https://flagz4u.herokuapp.com/images/flags/netherlands.png"
+              src="https://world-of-flags-backend.herokuapp.com/images/flags/netherlands.png"
             />
           </div>,
           <div
@@ -587,7 +587,7 @@ ShallowWrapper {
             "children": <img
               alt=""
               className="flag-image"
-              src="https://flagz4u.herokuapp.com/images/flags/netherlands.png"
+              src="https://world-of-flags-backend.herokuapp.com/images/flags/netherlands.png"
             />,
             "className": "flag-main",
           },
@@ -599,7 +599,7 @@ ShallowWrapper {
             "props": Object {
               "alt": "",
               "className": "flag-image",
-              "src": "https://flagz4u.herokuapp.com/images/flags/netherlands.png",
+              "src": "https://world-of-flags-backend.herokuapp.com/images/flags/netherlands.png",
             },
             "ref": null,
             "rendered": null,

--- a/src/utilities/API.js
+++ b/src/utilities/API.js
@@ -6,7 +6,7 @@ export const fetchData = async url => {
 
 export const addUser = async (name, email, password) => {
   try {
-    const url = 'https://flagz4u.herokuapp.com/signup'
+    const url = 'https://world-of-flags-backend.herokuapp.com/signup'
     const response = await fetch(url, {
       method: 'POST',
       body: JSON.stringify({
@@ -28,7 +28,7 @@ export const addUser = async (name, email, password) => {
 
 export const getUser = async (email, password, id, username) => {
   try {
-    const url = 'https://flagz4u.herokuapp.com/signin'
+    const url = 'https://world-of-flags-backend.herokuapp.com/signin'
     const response = await fetch(url, {
       method: 'POST',
       body: JSON.stringify({

--- a/src/utilities/Fetch.js
+++ b/src/utilities/Fetch.js
@@ -2,7 +2,7 @@ import * as API from './API'
 import { buildQuestion, checkCountry } from './helper'
 
 export const fetchCorrectCountry = async (randomId, usedCountries) => {
-  const url = `https://flagz4u.herokuapp.com/api/v1/country/${randomId}`
+  const url = `https://world-of-flags-backend.herokuapp.com/api/v1/country/${randomId}`
 
   const countryArray = await API.fetchData(url)
   const correctCountry = countryArray[0]
@@ -18,7 +18,7 @@ export const fetchCorrectCountry = async (randomId, usedCountries) => {
 }
 
 export const fetchCountryFacts = async countryId => {
-  const url = `https://flagz4u.herokuapp.com/api/v1/facts/${countryId}`
+  const url = `https://world-of-flags-backend.herokuapp.com/api/v1/facts/${countryId}`
 
   const countryFacts = await API.fetchData(url)
   return countryFacts

--- a/src/utilities/test/API.test.js
+++ b/src/utilities/test/API.test.js
@@ -1,5 +1,4 @@
 import * as API from '../API'
-// jest.mock('../API');
 
 describe('API', () => {
   describe('fetchData', () => {
@@ -48,15 +47,15 @@ describe('API', () => {
     })
 
     it('should call fetch on path /api/signup', () => {
-      const url = 'https://flagz4u.herokuapp.com/signup'
+      const url = 'https://world-of-flags-backend.herokuapp.com/signup'
       const body = {
-        body: '{"username":"https://flagz4u.herokuapp.com/signup"}',
+        body: '{"username":"https://world-of-flags-backend.herokuapp.com/signup"}',
         headers: { 'Content-Type': 'application/json' },
         method: 'POST',
       }
       const expected = {
         body:
-          '{"username":"https://flagz4u.herokuapp.com/signup","email":{"body":"{\\"username\\":\\"https://flagz4u.herokuapp.com/signup\\"}","headers":{"Content-Type":"application/json"},"method":"POST"}}',
+          '{"username":"https://world-of-flags-backend.herokuapp.com/signup","email":{"body":"{\\"username\\":\\"https://world-of-flags-backend.herokuapp.com/signup\\"}","headers":{"Content-Type":"application/json"},"method":"POST"}}',
         headers: { 'Content-Type': 'application/json' },
         method: 'POST',
       }
@@ -65,7 +64,7 @@ describe('API', () => {
     })
 
     it("Should return json'd response from fetch", async () => {
-      const url = 'https://flagz4u.herokuapp.com/signup'
+      const url = 'https://world-of-flags-backend.herokuapp.com/signup'
       const expected = { data: mockUser }
       const response = await API.fetchData(url)
       expect(response).toEqual(expected)
@@ -99,14 +98,14 @@ describe('API', () => {
     })
 
     it('should call fetch on path /api/signin with correct params', () => {
-      const expected = {"body": "{\"email\":\"https://flagz4u.herokuapp.com/signin\"}", "headers": {"Content-Type": "application/json"}, "method": "POST"}
-      const url = 'https://flagz4u.herokuapp.com/signin'
+      const expected = {"body": "{\"email\":\"https://world-of-flags-backend.herokuapp.com/signin\"}", "headers": {"Content-Type": "application/json"}, "method": "POST"}
+      const url = 'https://world-of-flags-backend.herokuapp.com/signin'
       API.getUser(url)
       expect(window.fetch).toHaveBeenCalledWith(url, expected)
     })
 
     it("Should return json'd response from fetch", async () => {
-      const url = 'https://flagz4u.herokuapp.com/signin'
+      const url = 'https://world-of-flags-backend.herokuapp.com/signin'
       const expected = { data: mockUser }
       const response = await API.fetchData(url)
       expect(response).toEqual(expected)

--- a/src/utilities/test/Fetch.test.js
+++ b/src/utilities/test/Fetch.test.js
@@ -15,7 +15,7 @@ describe('Fetch', () => {
     beforeEach(() => {
       mockId = 79
       mockUsedCountries = ['Sweden', 'Denmark', 'Nigeria', 'Australia']
-      url = `https://flagz4u.herokuapp.com/api/v1/country/${mockId}`
+      url = `https://world-of-flags-backend.herokuapp.com/api/v1/country/${mockId}`
       helper.checkCountry = jest.fn().mockImplementation(() => {
         return false
       })
@@ -104,7 +104,7 @@ describe('Fetch', () => {
         },
       ]
 
-      url = `https://flagz4u.herokuapp.com/api/v1/facts/${mockId}`
+      url = `https://world-of-flags-backend.herokuapp.com/api/v1/facts/${mockId}`
     })
 
     API.fetchData = jest.fn().mockImplementation(() => {
@@ -121,21 +121,4 @@ describe('Fetch', () => {
       expect(API.fetchData).toHaveReturnedWith(mockCountryFacts)
     })
   })
-
-  //  describe('fetchAllCountries', () => {
-  // 		let url;
-  //     beforeEach(() => {
-  // 			url = 'https://flagz4u.herokuapp.com/api/v1/country';
-  //     })
-
-  //     it('should call fetchCountries with the correct URL', async () => {
-  //     		Fetch.fetchAllCountries();
-  //     		expect(API.fetchData).toHaveBeenCalledWith(url)
-  //     })
-
-  //     it('should return a resolved array', async () => {
-  //     		const countries = await Fetch.fetchAllCountries();
-  //     		expect(countries.results).toEqual([])
-  //   })
-  // })
 })


### PR DESCRIPTION
## Description:

This PR addresses issue #`104`.

The changes made to the codebase in this PR:

* Changed URLs from `flagz4u` to `world-of-flags-backend` in Game, Hint, API, and Fetch.
* Fixed failing tests in each of the above components/utilities by likewise changing URLs. 
* 'Remove console.logs from Hint and Result components'

## Requests for review

Areas of concern:

* Ensure that user login, user creation, flag images, and country outlines work.
* Verify that Albania's country outline renders, as it did not when I tried it last.

